### PR TITLE
Add DASK_LOCAL_DIR environment variable

### DIFF
--- a/utils/dask-setup.sh
+++ b/utils/dask-setup.sh
@@ -14,7 +14,7 @@ MASTER_IPADDR=$7
 WHOAMI=$8
 LOG=$9
 
-DASK_LOCAL_DIR=./.dask
+DASK_LOCAL_DIR=${DASK_LOCAL_DIR:-./.dask}
 NUM_GPUS=$(nvidia-smi --list-gpus | wc --lines)
 MY_IPADDR=($(hostname --all-ip-addresses))
 

--- a/utils/dask-setup.sh
+++ b/utils/dask-setup.sh
@@ -14,7 +14,7 @@ MASTER_IPADDR=$7
 WHOAMI=$8
 LOG=$9
 
-DASK_LOCAL_DIR=${DASK_LOCAL_DIR:-./.dask}
+DASK_LOCAL_DIR=./.dask
 NUM_GPUS=$(nvidia-smi --list-gpus | wc --lines)
 MY_IPADDR=($(hostname --all-ip-addresses))
 


### PR DESCRIPTION
The dask setup script writes to a run directory in the current working directory.

Add an environment variable to provide some control over the run directory location.  E.g., if the current working directory is not writable, allow the user to specify an alternate location by setting DASK_LOCAL_DIR.