### PR TITLE
[REVIEW] Add environment variable to disable NCCL P2P for dask-xgboost

### DIFF
--- a/mortgage/E2E.ipynb
+++ b/mortgage/E2E.ipynb
@@ -47,6 +47,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%env NCCL_P2P_DISABLE=1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "import dask_xgboost as dxgb_gpu\n",
     "import dask\n",


### PR DESCRIPTION
Environment variable used to be set in dask_setup.sh script which is no longer used. Don't want to set it globally in container as it could affect cuML / cuGraph inadvertently. 