### PR TITLE
[REVIEW] update notebooks to reflect python api changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
+- PR #184 Renumber and louvain apis changed
 
 # Notebooks 0.8.0 (27 June 2019)
 

--- a/cugraph/Louvain.ipynb
+++ b/cugraph/Louvain.ipynb
@@ -186,17 +186,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Call Louvain on the graph\n",
-    "df, mod = cugraph.nvLouvain(G) "
+    "df, mod = cugraph.louvain(G) "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -229,7 +229,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,14 +250,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Found 4 partition\n"
+      "4 partition detected\n"
      ]
     }
    ],

--- a/cugraph/Renumber.ipynb
+++ b/cugraph/Renumber.ipynb
@@ -271,9 +271,7 @@
     }
    ],
    "source": [
-    "G = cugraph.Graph()\n",
-    "\n",
-    "src_r, dst_r, numbering = G.renumber(gdf['source_as_int'], gdf['dest_as_int'])\n",
+    "src_r, dst_r, numbering = cugraph.renumber(gdf['source_as_int'], gdf['dest_as_int'])\n",
     "\n",
     "gdf.add_column(\"original id\", numbering)\n",
     "gdf.add_column(\"src_renumbered\", src_r)\n",
@@ -433,6 +431,7 @@
     }
    ],
    "source": [
+    "G = cugraph.Graph()\n",
     "G.add_edge_list(src_r, dst_r)\n",
     "\n",
     "pr = cugraph.pagerank(G)\n",
@@ -557,6 +556,13 @@
     "Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.\n",
     "___"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The cugraph python api changed the renumber and louvain calls.  Update the notebooks to reflect those changes.
