### PR TITLE
Reduce size of cudf notebook final example by half, fixing OOM

### DIFF
--- a/cudf/notebooks_Apply_Operations_in_cuDF.ipynb
+++ b/cudf/notebooks_Apply_Operations_in_cuDF.ipynb
@@ -186,8 +186,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cuDF time 1.2836346626281738\n",
-      "pandas time 6.339383363723755\n"
+      "cuDF time 0.7422566413879395\n",
+      "pandas time 13.539819955825806\n"
      ]
     }
    ],
@@ -198,7 +198,7 @@
     "from numba import cuda\n",
     "import time\n",
     " \n",
-    "data_length = int(1e9)\n",
+    "data_length = int(5e8)\n",
     "average_window = 4\n",
     "df = cudf.dataframe.DataFrame()\n",
     "threads_per_block = 128\n",
@@ -265,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above code, we divide the array into subarrays of size \"trunk_size\", and send those subarrays to GPU blocks to compute moving average. However, there is no history for the elements at the beginning of the subarray. To fix this, we shift the chunk division by an offset of \"average_window\". Then we call the kernel2 to compute the moving average of those missing records only.. Note, in kernel2, we didn't define outcols as it will create a new GPU memory buffer and overwrite the old \"out\" values. Instead, we reuse out array as input. For an array of 1e9 length, cuDF uses 1.387s to do the computation while pandas use 7.58s. \n",
+    "In the above code, we divide the array into subarrays of size \"trunk_size\", and send those subarrays to GPU blocks to compute moving average. However, there is no history for the elements at the beginning of the subarray. To fix this, we shift the chunk division by an offset of \"average_window\". Then we call the kernel2 to compute the moving average of those missing records only.. Note, in kernel2, we didn't define outcols as it will create a new GPU memory buffer and overwrite the old \"out\" values. Instead, we reuse out array as input. For an array of 5e8 length, cuDF uses 0.74s to do the computation while pandas use 13.54s. \n",
     "\n",
     "This code is not optimized in performance. There are a few things we can do to make it faster. First, we can use shared memory to load the array and reduce the IO when doing the summation. Secondly, there is a lot of redundant summation done by the threads. We can maintain an accumulation summation array to help reduce the redundancy. This is outside the scope of this tutorial."
    ]
@@ -294,7 +294,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A failure in CI for release 0.9 is occurring due to OOM in this notebook. I've reduced the footprint of the memory usage by half in this final example, which should green up CI for the 0.9 release.