### PR TITLE
[HOTFIX] [REVIEW] updated the ridge regression notebook 

### DIFF
--- a/cuml/ridge_regression_demo.ipynb
+++ b/cuml/ridge_regression_demo.ipynb
@@ -168,10 +168,12 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "# run the cuml ridge regression model to fit the training dataset.  Eig is the faster algorithm, but svd is more accurate \n",
+    "# Run the cuml ridge regression model to fit the training dataset. Eig is the faster algorithm, but svd is more accurate.\n",
+    "# In general svd uses significantly more memory and is slower than eig.\n",
+    "# If using CUDA 10.1, the memory difference is even bigger than in the other supported CUDA versions\n",
     "ridge_cuml = cuRidge(fit_intercept=False,\n",
     "                     normalize=True,\n",
-    "                     solver='svd',\n",
+    "                     solver='eig',\n",
     "                     alpha=0.1)\n",
     "\n",
     "ridge_cuml.fit(X_cudf, y_cudf)"
@@ -223,7 +225,7 @@
  "metadata": {
   "celltoolbar": "Raw Cell Format",
   "kernelspec": {
-   "display_name": "cuml4",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -237,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated the ridge regression notebooks to use the 'eig' solver. 
Comments in the notebook have been updated to provide information regarding the difference in the memory consumed by the two solvers.