### PR TITLE
Fix cuxfilter name casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - [cuGraph Notebooks](https://github.com/rapidsai/cugraph/tree/branch-0.17/notebooks)
 - [CLX Notebooks](https://github.com/rapidsai/clx/tree/branch-0.17/notebooks)
 - [cuSpatial Notebooks](https://github.com/rapidsai/cuspatial/tree/branch-0.17/notebooks)
-- [cuXfilter Notebooks](https://github.com/rapidsai/cuxfilter/tree/branch-0.17/notebooks)
+- [cuxfilter Notebooks](https://github.com/rapidsai/cuxfilter/tree/branch-0.17/notebooks)
 - [XGBoost Notebooks](https://github.com/rapidsai/xgboost-conda/tree/branch-0.17/notebooks)
 
 ## Intro


### PR DESCRIPTION
According to issue https://github.com/rapidsai/cuxfilter/issues/170, 'cuxfilter' is the correct way to refer to this library (https://github.com/rapidsai/cuxfilter).

I have amended this readme because it is the only remaining place where cuxfilter naming is not consistent.

Hope it helps!