### PR TITLE
Add `cuspatial` symlink

### DIFF
--- a/cuspatial
+++ b/cuspatial
@@ -1,0 +1,1 @@
+repos/cuspatial


### PR DESCRIPTION
This PR adds a missing symlink for the `cuspatial` library.